### PR TITLE
Add source-control-url to publish workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,4 +28,5 @@ jobs:
       - run: |
           GOOS=wasip1 GOARCH=wasm go build -o buf-check-reserved-keywords.wasm .
           buf plugin push buf.build/svanburenorg/reserved-keywords \
-              --binary=buf-check-reserved-keywords.wasm
+              --binary=buf-check-reserved-keywords.wasm \
+              --source-control-url=https://github.com/${{github.repository}}/commit/${{github.sha}}


### PR DESCRIPTION
Using GitHub Actions context.

Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context