### PR TITLE
test: Drop testify direct dep for stdlib assertions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.2
 
 require (
 	buf.build/go/bufplugin v0.10.0
-	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -23,6 +22,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/mod v0.27.0 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"buf.build/go/bufplugin/check"
 	"buf.build/go/bufplugin/check/checktest"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSpec(t *testing.T) {
@@ -601,14 +601,23 @@ func TestRule(t *testing.T) {
 
 				ctx := t.Context()
 				request, err := requestSpec.ToRequest(ctx)
-				require.NoError(t, err)
+				if err != nil {
+					t.Fatal(err)
+				}
 				client, err := check.NewClientForSpec(spec)
-				require.NoError(t, err)
+				if err != nil {
+					t.Fatal(err)
+				}
 				_, err = client.Check(ctx, request)
-				require.Error(t, err)
+				if err == nil {
+					t.Fatal("expected error")
+				}
 				// Just check the prefix, so this doesn't fail as we add new supported
 				// languages.
-				require.ErrorContains(t, err, `Failed with code unknown: parsing options: invalid language given "invalid", expected one of:`)
+				const want = `Failed with code unknown: parsing options: invalid language given "invalid", expected one of:`
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("got %q, want substring %q", err, want)
+				}
 			})
 			t.Run("valid", func(t *testing.T) {
 				requestSpec := newRequestSpec(


### PR DESCRIPTION
Replaces the four testify assertions in `main_test.go` with plain stdlib `if`/`t.Fatal` checks.

testify stays in the module graph as an indirect dep (bufplugin's own tests require it transitively, so it can't be removed), but it is no longer a direct dependency and no new assertion library is pulled in.