### PR TITLE
Move module to go.vanburen.xyz/buf-check-reserved-keywords vanity path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stefanvanburen/buf-check-reserved-keywords
+module go.vanburen.xyz/buf-check-reserved-keywords
 
 go 1.26.2
 

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var spec = &check.Spec{
 	Info: &info.Spec{
 		Documentation: readmeMarkdown,
 		SPDXLicenseID: "apache-2.0",
-		LicenseURL:    "https://github.com/stefanvanburen/buf-check-reserved-keywords/blob/main/LICENSE",
+		LicenseURL:    "https://go.vanburen.xyz/buf-check-reserved-keywords/blob/main/LICENSE",
 	},
 }
 


### PR DESCRIPTION
Module path migration to the go.vanburen.xyz vanity domain.

https://claude.ai/code/session_01Cd1Smog1xcgyHDXVuupGux